### PR TITLE
Minor fixes

### DIFF
--- a/include/modules/hyprland/workspace.hpp
+++ b/include/modules/hyprland/workspace.hpp
@@ -4,6 +4,7 @@
 #include <gtkmm/label.h>
 #include <json/value.h>
 
+#include <algorithm>
 #include <cstddef>
 #include <cstdint>
 #include <map>

--- a/meson.build
+++ b/meson.build
@@ -77,11 +77,18 @@ wayland_protos = dependency('wayland-protocols')
 gtkmm = dependency('gtkmm-4.0', version : ['=4.20.0'], fallback : ['gtkmm', 'gtkmm_dep'])
 giomm = dependency('giomm-2.4', version : ['>=2.40.0'])
 giounix = dependency('gio-unix-2.0')
-jsoncpp = dependency('jsoncpp', version : ['>=1.9.8'], fallback : ['jsoncpp', 'jsoncpp_dep'])
+jsoncpp = dependency('jsoncpp', version : ['>=1.9.6'], fallback : ['jsoncpp', 'jsoncpp_dep'])
 sigcpp = dependency('sigc++-3.0')
 libepoll = dependency('epoll-shim', required: false)
 
+# Must be declared and linked before wayland_client dep.
+# Otherwise gtk_layer_is_supported() returns false at runtime.
+gtk_layer_shell = dependency('gtk4-layer-shell-0', version: ['>=1.3.0'],
+        default_options: ['introspection=false', 'vapi=false'],
+        fallback: ['gtk-layer-shell', 'gtk_layer_shell'])
+
 deps += [thread_dep,
+         gtk_layer_shell,
          wayland_client,
          wayland_cursor,
          gtkmm,
@@ -104,16 +111,13 @@ if libsndio.found()
 endif
 deps += libsndio
 
-gtk_layer_shell = dependency('gtk4-layer-shell-0', version: ['>=1.3.0'],
-        default_options: ['introspection=false', 'vapi=false'],
-        fallback: ['gtk-layer-shell', 'gtk_layer_shell'])
 systemd = dependency('systemd', required: get_option('systemd'))
 libsystemd = dependency('libsystemd', required: get_option('systemd'))
 if libsystemd.found()
     add_project_arguments('-DHAVE_LIBSYSTEMD', language: 'cpp')
 endif
 
-deps += [gtk_layer_shell, systemd, libsystemd]
+deps += [systemd, libsystemd]
 
 cpp_lib_chrono = compiler.compute_int('__cpp_lib_chrono', prefix : '#include <chrono>')
 have_chrono_timezones = cpp_lib_chrono >= 201611

--- a/src/ALabel.cpp
+++ b/src/ALabel.cpp
@@ -2,6 +2,7 @@
 
 #include <fmt/format.h>
 
+#include <algorithm>
 #include <fstream>
 #include <iostream>
 #include <util/command.hpp>

--- a/src/modules/temperature.cpp
+++ b/src/modules/temperature.cpp
@@ -1,5 +1,6 @@
 #include "modules/temperature.hpp"
 
+#include <algorithm>
 #include <filesystem>
 #include <optional>
 #include <stdexcept>

--- a/src/util/gtk/gtk_icon.cpp
+++ b/src/util/gtk/gtk_icon.cpp
@@ -2,6 +2,8 @@
 
 #include <spdlog/spdlog.h>
 
+#include <algorithm>
+
 namespace waybar::util {
 
 std::mutex DefaultGtkIconThemeWrapper::default_theme_mutex;

--- a/src/util/hosts_check.cpp
+++ b/src/util/hosts_check.cpp
@@ -3,6 +3,8 @@
 #include <glibmm/miscutils.h>
 #include <json/config.h>
 
+#include <algorithm>
+
 namespace waybar::util {
 bool valid_host(const Json::Value& config) {
   if (config.isMember("hosts") && config["hosts"].isArray()) {


### PR DESCRIPTION
I have tried to build this branch on ArchLinux with GCC16 and encountered some minor issues:

1. GCC16's libstdc++ has removed transitive includes of `<algorithm>`. It must imported explicitly now.
2. `gtk4-layer-shell` must be linked before `libwayland-client`. It doesn't work otherwise.

Thanks for porting Waybar to GTK4!